### PR TITLE
Windows + Linux builds

### DIFF
--- a/esy.lock/index.json
+++ b/esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "aa8c99b81c40ded67237d08dee4e4a8b",
+  "checksum": "b24293ff88815c3ee2a95a0f5ad6f056",
   "root": "revery-quick-start@link-dev:./package.json",
   "node": {
     "revery-quick-start@link-dev:./package.json": {
@@ -14,7 +14,7 @@
       "overrides": [],
       "dependencies": [
         "revery@0.27.0@d41d8cd9", "ocaml@4.7.1004@d41d8cd9",
-        "@opam/portaudio@github:jordwalke/ocaml-portaudio:portaudio.opam#f592215935c51b11a3c0b969a5185ddc6c39cfa0@d41d8cd9",
+        "@opam/portaudio@github:bryphe/ocaml-portaudio#8af41a7@d41d8cd9",
         "@opam/dune@opam:1.7.3@e23fe0a7"
       ],
       "devDependencies": [
@@ -274,6 +274,20 @@
         "refmterr@3.2.2@d41d8cd9", "@opam/dune@opam:1.7.3@e23fe0a7",
         "@esy-ocaml/reason@3.5.0@d41d8cd9"
       ],
+      "devDependencies": []
+    },
+    "esy-portaudio@19.0.6001@d41d8cd9": {
+      "id": "esy-portaudio@19.0.6001@d41d8cd9",
+      "name": "esy-portaudio",
+      "version": "19.0.6001",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://registry.npmjs.org/esy-portaudio/-/esy-portaudio-19.0.6001.tgz#sha1:01e4ea5a7ea216a1b03fbd9a3b3e94daf54f41a0"
+        ]
+      },
+      "overrides": [],
+      "dependencies": [],
       "devDependencies": []
     },
     "esy-harfbuzz@1.9.1005@d41d8cd9": {
@@ -776,24 +790,20 @@
         "ocaml@4.7.1004@d41d8cd9", "@opam/dune@opam:1.7.3@e23fe0a7"
       ]
     },
-    "@opam/portaudio@github:jordwalke/ocaml-portaudio:portaudio.opam#f592215935c51b11a3c0b969a5185ddc6c39cfa0@d41d8cd9": {
-      "id":
-        "@opam/portaudio@github:jordwalke/ocaml-portaudio:portaudio.opam#f592215935c51b11a3c0b969a5185ddc6c39cfa0@d41d8cd9",
+    "@opam/portaudio@github:bryphe/ocaml-portaudio#8af41a7@d41d8cd9": {
+      "id": "@opam/portaudio@github:bryphe/ocaml-portaudio#8af41a7@d41d8cd9",
       "name": "@opam/portaudio",
-      "version":
-        "github:jordwalke/ocaml-portaudio:portaudio.opam#f592215935c51b11a3c0b969a5185ddc6c39cfa0",
+      "version": "github:bryphe/ocaml-portaudio#8af41a7",
       "source": {
         "type": "install",
-        "source": [
-          "github:jordwalke/ocaml-portaudio:portaudio.opam#f592215935c51b11a3c0b969a5185ddc6c39cfa0"
-        ]
+        "source": [ "github:bryphe/ocaml-portaudio#8af41a7" ]
       },
       "overrides": [],
       "dependencies": [
-        "ocaml@4.7.1004@d41d8cd9", "@opam/ocamlfind@opam:1.8.1@ff07b0f9",
-        "@esy-ocaml/substs@0.0.1@d41d8cd9"
+        "ocaml@4.7.1004@d41d8cd9", "esy-portaudio@19.0.6001@d41d8cd9",
+        "@opam/dune@opam:1.7.3@e23fe0a7"
       ],
-      "devDependencies": [ "ocaml@4.7.1004@d41d8cd9" ]
+      "devDependencies": []
     },
     "@opam/ocplib-endian@opam:1.0@aa720242": {
       "id": "@opam/ocplib-endian@opam:1.0@aa720242",
@@ -992,20 +1002,20 @@
         "@opam/dune@opam:1.7.3@e23fe0a7"
       ]
     },
-    "@opam/menhir@opam:20190626@bbeb8953": {
-      "id": "@opam/menhir@opam:20190626@bbeb8953",
+    "@opam/menhir@opam:20190924@004407ff": {
+      "id": "@opam/menhir@opam:20190924@004407ff",
       "name": "@opam/menhir",
-      "version": "opam:20190626",
+      "version": "opam:20190924",
       "source": {
         "type": "install",
         "source": [
-          "archive:https://opam.ocaml.org/cache/md5/78/783961f8d124449a1a335cc8e50f013f#md5:783961f8d124449a1a335cc8e50f013f",
-          "archive:https://gitlab.inria.fr/fpottier/menhir/repository/20190626/archive.tar.gz#md5:783961f8d124449a1a335cc8e50f013f"
+          "archive:https://opam.ocaml.org/cache/md5/67/677f1997fb73177d5a00fa1b8d61c3ef#md5:677f1997fb73177d5a00fa1b8d61c3ef",
+          "archive:https://gitlab.inria.fr/fpottier/menhir/repository/20190924/archive.tar.gz#md5:677f1997fb73177d5a00fa1b8d61c3ef"
         ],
         "opam": {
           "name": "menhir",
-          "version": "20190626",
-          "path": "esy.lock/opam/menhir.20190626"
+          "version": "20190924",
+          "path": "esy.lock/opam/menhir.20190924"
         }
       },
       "overrides": [],
@@ -1833,7 +1843,7 @@
       },
       "overrides": [],
       "dependencies": [
-        "ocaml@4.7.1004@d41d8cd9", "@opam/menhir@opam:20190626@bbeb8953",
+        "ocaml@4.7.1004@d41d8cd9", "@opam/menhir@opam:20190924@004407ff",
         "@opam/jbuilder@opam:transition@58bdfe0a",
         "@opam/easy-format@opam:1.3.1@9abfd4ed",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
@@ -1900,7 +1910,7 @@
         "@opam/ocamlfind@opam:1.8.1@ff07b0f9",
         "@opam/ocaml-migrate-parsetree@opam:1.3.1@8bfb3f95",
         "@opam/merlin-extend@opam:0.4@64c45329",
-        "@opam/menhir@opam:20190626@bbeb8953",
+        "@opam/menhir@opam:20190924@004407ff",
         "@opam/dune@opam:1.7.3@e23fe0a7"
       ],
       "devDependencies": []

--- a/esy.lock/index.json
+++ b/esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "b24293ff88815c3ee2a95a0f5ad6f056",
+  "checksum": "c5553e77c8def5e7e09ff4a9dba05518",
   "root": "revery-quick-start@link-dev:./package.json",
   "node": {
     "revery-quick-start@link-dev:./package.json": {
@@ -13,9 +13,9 @@
       },
       "overrides": [],
       "dependencies": [
-        "revery@0.27.0@d41d8cd9", "ocaml@4.7.1004@d41d8cd9",
-        "@opam/portaudio@github:bryphe/ocaml-portaudio#8af41a7@d41d8cd9",
-        "@opam/dune@opam:1.7.3@e23fe0a7"
+        "revery@0.27.0@d41d8cd9",
+        "ocaml-portaudio@github:bryphe/ocaml-portaudio#c849b06@d41d8cd9",
+        "ocaml@4.7.1004@d41d8cd9", "@opam/dune@opam:1.7.3@e23fe0a7"
       ],
       "devDependencies": [
         "ocaml@4.7.1004@d41d8cd9", "@opam/merlin@opam:3.2.2@e3edecdd"
@@ -243,6 +243,21 @@
       },
       "overrides": [],
       "dependencies": [],
+      "devDependencies": []
+    },
+    "ocaml-portaudio@github:bryphe/ocaml-portaudio#c849b06@d41d8cd9": {
+      "id": "ocaml-portaudio@github:bryphe/ocaml-portaudio#c849b06@d41d8cd9",
+      "name": "ocaml-portaudio",
+      "version": "github:bryphe/ocaml-portaudio#c849b06",
+      "source": {
+        "type": "install",
+        "source": [ "github:bryphe/ocaml-portaudio#c849b06" ]
+      },
+      "overrides": [],
+      "dependencies": [
+        "ocaml@4.7.1004@d41d8cd9", "esy-portaudio@19.0.6001@d41d8cd9",
+        "@opam/dune@opam:1.7.3@e23fe0a7"
+      ],
       "devDependencies": []
     },
     "ocaml@4.7.1004@d41d8cd9": {
@@ -789,21 +804,6 @@
       "devDependencies": [
         "ocaml@4.7.1004@d41d8cd9", "@opam/dune@opam:1.7.3@e23fe0a7"
       ]
-    },
-    "@opam/portaudio@github:bryphe/ocaml-portaudio#8af41a7@d41d8cd9": {
-      "id": "@opam/portaudio@github:bryphe/ocaml-portaudio#8af41a7@d41d8cd9",
-      "name": "@opam/portaudio",
-      "version": "github:bryphe/ocaml-portaudio#8af41a7",
-      "source": {
-        "type": "install",
-        "source": [ "github:bryphe/ocaml-portaudio#8af41a7" ]
-      },
-      "overrides": [],
-      "dependencies": [
-        "ocaml@4.7.1004@d41d8cd9", "esy-portaudio@19.0.6001@d41d8cd9",
-        "@opam/dune@opam:1.7.3@e23fe0a7"
-      ],
-      "devDependencies": []
     },
     "@opam/ocplib-endian@opam:1.0@aa720242": {
       "id": "@opam/ocplib-endian@opam:1.0@aa720242",

--- a/esy.lock/opam/menhir.20190924/opam
+++ b/esy.lock/opam/menhir.20190924/opam
@@ -21,9 +21,9 @@ depends: [
 synopsis: "An LR(1) parser generator"
 url {
   src:
-    "https://gitlab.inria.fr/fpottier/menhir/repository/20190626/archive.tar.gz"
+    "https://gitlab.inria.fr/fpottier/menhir/repository/20190924/archive.tar.gz"
   checksum: [
-    "md5=783961f8d124449a1a335cc8e50f013f"
-    "sha512=bacc5161682130d894a6476fb79363aa73e5582543265a0c23c9a1f9d974007c04853dc8f6faa2b8bd2e82b2323b8604dcc4cb74308af667698079b394dfd492"
+    "md5=677f1997fb73177d5a00fa1b8d61c3ef"
+    "sha512=ea8a9a6d773529cf6ac05e4c6c4532770fbb8e574c9b646efcefe90d9f24544741e3e8cfd94c8afea0447e34059a8c79c2829b46764ce3a3d6dcb3e7f75980fc"
   ]
 }

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "@opam/portaudio": "*"
   },
   "resolutions": {
-    "@opam/portaudio": "jordwalke/ocaml-portaudio:portaudio.opam#f592215935c51b11a3c0b969a5185ddc6c39cfa0",
+    "@opam/portaudio": "bryphe/ocaml-portaudio#8af41a7",
     "@opam/cmdliner": "1.0.2",
     "@opam/js_of_ocaml": "github:ocsigen/js_of_ocaml:js_of_ocaml.opam#db257ce",
     "@opam/js_of_ocaml-compiler": "github:ocsigen/js_of_ocaml:js_of_ocaml-compiler.opam#db257ce",

--- a/package.json
+++ b/package.json
@@ -14,10 +14,10 @@
     "ocaml": "~4.7.0",
     "revery": "0.27.0",
     "@opam/dune": "1.7.3",
-    "@opam/portaudio": "*"
+    "ocaml-portaudio": "*"
   },
   "resolutions": {
-    "@opam/portaudio": "bryphe/ocaml-portaudio#8af41a7",
+    "ocaml-portaudio": "github:bryphe/ocaml-portaudio#c849b06",
     "@opam/cmdliner": "1.0.2",
     "@opam/js_of_ocaml": "github:ocsigen/js_of_ocaml:js_of_ocaml.opam#db257ce",
     "@opam/js_of_ocaml-compiler": "github:ocsigen/js_of_ocaml:js_of_ocaml-compiler.opam#db257ce",


### PR DESCRIPTION
This just points `ocaml-portaudio` to a fork that builds on Windows / Linux.

As part of this, added [`esy-portaudio`](https://github.com/esy-packages/esy-portaudio) which builds `libportaudio`, and then the fork w/ the OCaml bindings brings in `esy-portaudio` as a dependency, and has a build step to add the right link flags.

Works great on Windows now 😎 

![image](https://user-images.githubusercontent.com/13532591/65543761-b1d61900-dec6-11e9-9937-276ef69f2fdb.png)

And tested on Manjaro Linux - I couldn't test the audio output but everything built / ran:
![image](https://user-images.githubusercontent.com/13532591/65544032-4771a880-dec7-11e9-94e0-2daa56e46ae7.png)
