### PR TITLE
Packaging: Distributable builds via revery-packager

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,6 +64,7 @@ typings/
 # esy 
 _build/
 _esy/
+_release/
 
 # reason
 *.install

--- a/esy.lock/index.json
+++ b/esy.lock/index.json
@@ -1,5 +1,5 @@
 {
-  "checksum": "ac2ee02fc16e5f940c74f61039de7bc5",
+  "checksum": "0f77a4a072381ccf2ca6074792b3fdb1",
   "root": "revery-quick-start@link-dev:./package.json",
   "node": {
     "revery-quick-start@link-dev:./package.json": {
@@ -20,7 +20,8 @@
         "@opam/dune@opam:1.7.3@e23fe0a7"
       ],
       "devDependencies": [
-        "ocaml@4.7.1004@d41d8cd9", "@opam/merlin@opam:3.2.2@e3edecdd"
+        "ocaml@4.7.1004@d41d8cd9", "esy-macdylibbundler@0.4.5@d41d8cd9",
+        "@opam/merlin@opam:3.2.2@e3edecdd"
       ]
     },
     "revery@0.27.0@d41d8cd9": {
@@ -305,6 +306,20 @@
       },
       "overrides": [],
       "dependencies": [],
+      "devDependencies": []
+    },
+    "esy-macdylibbundler@0.4.5@d41d8cd9": {
+      "id": "esy-macdylibbundler@0.4.5@d41d8cd9",
+      "name": "esy-macdylibbundler",
+      "version": "0.4.5",
+      "source": {
+        "type": "install",
+        "source": [
+          "archive:https://registry.npmjs.org/esy-macdylibbundler/-/esy-macdylibbundler-0.4.5.tgz#sha1:f4aeadafe072b8fce9603a6da3cd10fa15c23495"
+        ]
+      },
+      "overrides": [],
+      "dependencies": [ "esy-cmake@0.3.5@d41d8cd9" ],
       "devDependencies": []
     },
     "esy-harfbuzz@1.9.1005@d41d8cd9": {

--- a/package.json
+++ b/package.json
@@ -3,6 +3,12 @@
   "version": "1.3.0",
   "description": "Revery quickstart",
   "license": "MIT",
+  "revery-packager": {
+    "bundleName": "CamlSynthApp",
+    "bundleId": "com.kenwheeler.camlsynth",
+    "displayName": "ML-808 CamlSynth",
+    "mainExecutable": "App"
+  },
   "esy": {
     "build": "refmterr dune build -p App",
     "buildsInSource": "_build",
@@ -35,6 +41,7 @@
   },
   "devDependencies": {
     "ocaml": "~4.7.0",
-    "@opam/merlin": "*"
+    "@opam/merlin": "*",
+    "esy-macdylibbundler": "*"
   }
 }


### PR DESCRIPTION
I ported over some of the scripts we use to package Onivim 2 into [revery-packager](https://github.com/revery-ui/revery-packager), and published it as an NPM package.

The tool is basically independent; this PR just adds a little metadata to help out (and of course feel free to tweak the names and stuff 😎 )

The steps to create a redistributable package are:
- Install `revery-packager`: `npm install -g revery-packager`
- Run `revery-packager` from the `camlsynth` dir

This will show a bunch of output and then put release artifacts in the `_release` folder:

- Windows: 
  -  `CamlSynthApp-win32-x64.zip`

- OSX:
  - `CamlSynthApp.dmg`
  - `CamlSynthApp-darwin.tar.gz`

- Linux:
  - `CamlSynthApp-x86_64.AppImage`
  - `CamlSynthApp-linux.tar.gz`

It's really rough and basic, and probably missing some stuff... but we can give it a try if you're up for it.